### PR TITLE
fix(vercel): Correct filename to resolve deployment error

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './app.jsx'
+import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>


### PR DESCRIPTION
Addresses a deployment error on Vercel caused by an incorrect filename.

- Identifies the problematic filename.
- Renames the file to comply with Vercel's requirements (e.g., case sensitivity).